### PR TITLE
C/C++: Use single-precision variants of math functions when appropriate

### DIFF
--- a/modelparameters/codegeneration.py
+++ b/modelparameters/codegeneration.py
@@ -641,17 +641,59 @@ class _CustomCCodePrinter(_StrPrinter):
             return expr.func.__name__
 
         # add special case for math functions
-        math_functions = [
-            "exp",
-            "log",
-            "pow",
-            "sqrt",
+        math_functions_with_float_variant = [
             "fabs",
-            "floor",
-            "ceil",
             "fmod",
+            "remainder",
+            "remquo",
+            "fma",
+            "fmax",
+            "fmin",
+            "fdim",
+
+            "exp",
+            "exp2",
+            "expm1",
+            "log",
+            "log2",
+            "log10",
+            "log1p",
+            "ilogb",
+            "logb",
+
+            "hypot",
+            "cbrt",
+            "sqrt",
+            "pow",
+
+            "sin",
+            "cos",
+            "tan",
+            "asin",
+            "acos",
+            "atan",
+            "atan2",
+
+            "sinh",
+            "cosh",
+            "tanh",
+            "asinh",
+            "acosh",
+            "atanh",
+
+            "erf",
+            "erfc",
+            "lgamma",
+            "tgamma",
+
+            "ceil",
+            "floor",
+            "trunc",
+            "round",
+            "nearbyint",
+            "rint",
         ]
-        if expr.func.__name__.lower() in math_functions:
+        if expr.func.__name__.lower() in math_functions_with_float_variant:
             return self.__print_math_function(
                 expr.func.__name__.lower(),
                 self.stringify(expr.args, ", ")

--- a/modelparameters/codegeneration.py
+++ b/modelparameters/codegeneration.py
@@ -560,7 +560,8 @@ class _CustomCCodePrinter(_StrPrinter):
         self._math_suffix = "" if float_precision == "double" else "f"
         self._float_postfix = "" if float_precision == "double" else "f"
 
-    def __print_math_function(self, function_name, arguments_str):
+    def _print_math_function(self, function_name, arguments_str):
+        # add the appropriate namespace and suffix for math functions
         return "{namespace}{name}{suffix}({arguments})".format(
             namespace = self._prefix,
             name = function_name,
@@ -598,32 +599,32 @@ class _CustomCCodePrinter(_StrPrinter):
 
     def _print_Min(self, expr):
         "fmin and fmax is not contained in std namespace untill -ansi g++ 4.7"
-        return self.__print_math_function(
+        return self._print_math_function(
             "fmin",
             self.stringify(expr.args, ", ")
         )
 
     def _print_Max(self, expr):
         "fmin and fmax is not contained in std namespace untill -ansi g++ 4.7"
-        return self.__print_math_function(
+        return self._print_math_function(
             "fmax",
             self.stringify(expr.args, ", ")
         )
 
     def _print_Ceiling(self, expr):
-        return self.__print_math_function(
+        return self._print_math_function(
             "ceil",
             self.stringify(expr.args, ", ")
         )
 
     def _print_Abs(self, expr):
-        return self.__print_math_function(
+        return self._print_math_function(
             "fabs",
             self.stringify(expr.args, ", ")
         )
 
     def _print_Mod(self, expr):
-        return self.__print_math_function(
+        return self._print_math_function(
             "fmod",
             self.stringify(expr.args, ", ")
         )
@@ -645,7 +646,7 @@ class _CustomCCodePrinter(_StrPrinter):
                 a, b = b, a
 
             if type(a) is sp.exp and type(b) is sp.numbers.NegativeOne:
-                return self.__print_math_function(
+                return self._print_math_function(
                     "expm1",
                     self.stringify(a.args, ", ")
                 )
@@ -711,7 +712,7 @@ class _CustomCCodePrinter(_StrPrinter):
             "rint",
         ]
         if expr.func.__name__.lower() in math_functions_with_float_variant:
-            return self.__print_math_function(
+            return self._print_math_function(
                 expr.func.__name__.lower(),
                 self.stringify(expr.args, ", ")
             )
@@ -757,18 +758,18 @@ class _CustomCCodePrinter(_StrPrinter):
                 "*".join(self.parenthesize(expr.base, PREC) \
                          for i in range(-int(expr.exp))), self._float_postfix)
         if expr.exp is sp.S.Half and not rational:
-            return self.__print_math_function(
+            return self._print_math_function(
                 "sqrt",
                 self._print(expr.base)
             )
         if expr.exp == -0.5:
             return "1/{}".format(
-                self.__print_math_function(
+                self._print_math_function(
                     "sqrt",
                     self._print(expr.base)
                 )
             )
-        return self.__print_math_function(
+        return self._print_math_function(
                 "pow",
                 "{0}, {1}".format(self._print(expr.base), self._print(expr.exp))
             )

--- a/modelparameters/codegeneration.py
+++ b/modelparameters/codegeneration.py
@@ -635,6 +635,23 @@ class _CustomCCodePrinter(_StrPrinter):
         last_line = "{0})".format(self._print(expr.args[-1].expr))
         return result+last_line
 
+    def _print_Add(self, expr):
+        args = expr.args
+
+        # Special treatment of (exp(a) - 1), where we should use expm1
+        if len(args) == 2:
+            a, b = args
+            if type(b) == sp.exp:
+                a, b = b, a
+
+            if type(a) is sp.exp and type(b) is sp.numbers.NegativeOne:
+                return self.__print_math_function(
+                    "expm1",
+                    self.stringify(a.args, ", ")
+                )
+
+        return super()._print_Add(expr)
+
     def _print_Function(self, expr):
         #print expr.func.__name__, expr.args
         if isinstance(expr, _AppliedUndef):

--- a/modelparameters/codegeneration.py
+++ b/modelparameters/codegeneration.py
@@ -740,7 +740,7 @@ class _CustomCCodePrinter(_StrPrinter):
         if expr.exp.is_integer and int(expr.exp) == 1:
             return self.parenthesize(expr.base, PREC)
         if expr.exp is sp.S.NegativeOne:
-            return "1.0{1}/{0}".format(self.parenthesize(expr.base, PREC), self._float_postfix)
+            return "1.0{0}/{1}".format(self._float_postfix, self.parenthesize(expr.base, PREC))
         if expr.exp.is_integer and int(expr.exp) in [2, 3]:
             return "({0})".format(\
                 "*".join(self.parenthesize(expr.base, PREC) \


### PR DESCRIPTION
This PR fixes a number of issues with generating single-precision code. The issues fall into two main categories:
- Float literals lacking an `f` suffix.
- Math library function calls returning a double value. These have now been replaced with the equivalent single-precision variant.

I used https://en.wikipedia.org/wiki/C_mathematical_functions for an exhaustive list of math functions in C and filtered out those without single-precision variants.

Additionally, I have added a special case to rewrite `(exp(a) - 1)` as `(expm1(a))` to increase the precision when this expression is near zero.