### PR TITLE
Remove six as dependency

### DIFF
--- a/modelparameters/parameterdict.py
+++ b/modelparameters/parameterdict.py
@@ -19,9 +19,6 @@ Contains the ParameterDict class, useful for defining
 recursive dictionaries of parameters and using attribute
 syntax for later access.
 """
-import six
-
-
 # System imports
 try:
     from .sympytools import sp
@@ -206,8 +203,7 @@ class ParameterDict(dict):
     def __repr__(self):
         return "ParameterDict(%s)" % (
             ", ".join(
-                "%s=%s" % (k, repr(v))
-                for k, v in sorted(six.iteritems(self), key=par_cmp)
+                "%s=%s" % (k, repr(v)) for k, v in sorted(self.items(), key=par_cmp)
             )
         )
 
@@ -288,7 +284,7 @@ class ParameterDict(dict):
             If True each encountered ParameterDict will be entered
 
         """
-        for key, value in sorted(six.iteritems(self), key=par_cmp):
+        for key, value in sorted(self.items(), key=par_cmp):
             if isinstance(value, ParameterDict) and recurse:
                 for new_value in value.iterparams(recurse):
                     yield new_value
@@ -305,7 +301,7 @@ class ParameterDict(dict):
             If True each encountered ParameterDict will also be entered
 
         """
-        for key, value in sorted(six.iteritems(self), key=par_cmp):
+        for key, value in sorted(self.items(), key=par_cmp):
             if isinstance(value, ParameterDict):
                 yield value
 
@@ -320,19 +316,19 @@ class ParameterDict(dict):
         max_key_length = 0
         max_value_length = 0
         max_length = 15
-        for key, value in six.iteritems(self):
+        for key, value in self.items():
             if not isinstance(value, ParameterDict):
                 if len(key) > max_key_length:
                     max_key_length = min(len(key), max_length)
                 value_length = (
                     value.format_width()
                     if isinstance(value, Param)
-                    else len(six.text_type(value))
+                    else len(str(value))
                 )
                 if value_length > max_value_length:
                     max_value_length = min(value_length, max_length)
         s = []
-        for key, value in sorted(six.iteritems(self), key=par_cmp):
+        for key, value in sorted(self.items(), key=par_cmp):
 
             # If the value is a ParameterDict
             if isinstance(value, ParameterDict):
@@ -354,7 +350,7 @@ class ParameterDict(dict):
                     + "%s = %s"
                     % (
                         KEY_JUST(key, max_key_length),
-                        VALUE_JUST(six.text_type(value), max_value_length),
+                        VALUE_JUST(str(value), max_value_length),
                     ),
                 )
 
@@ -372,7 +368,7 @@ class ParameterDict(dict):
             Parameters
         """
         items = {}
-        for key in six.iterkeys(self):
+        for key in self.keys():
             value = dict.__getitem__(self, key)
 
             # If the value is a ParameterDict
@@ -402,7 +398,7 @@ class ParameterDict(dict):
         """
         check_arg(other, dict, 0, ParameterDict.update)
 
-        for key in six.iterkeys(other):
+        for key in other.keys():
             if key not in self:
                 continue
             self_value = self[key]
@@ -452,7 +448,7 @@ class ParameterDict(dict):
                     except ValueError as e:
                         value_error(
                             "Trying to set '%s' while parsing "
-                            "command line, but %s" % (key, six.text_type(e)),
+                            "command line, but %s" % (key, str(e)),
                         )
 
             else:
@@ -481,7 +477,7 @@ class ParameterDict(dict):
                                         arg,
                                         sequence_type.__name__,
                                         key,
-                                        six.text_type(e),
+                                        str(e),
                                     ),
                                 )
 
@@ -495,13 +491,13 @@ class ParameterDict(dict):
                     except ValueError as e:
                         value_error(
                             "Trying to set '%s' while parsing "
-                            "command line, but %s" % (key, six.text_type(e)),
+                            "command line, but %s" % (key, str(e)),
                         )
 
             return par_setter
 
         def add_options(parent, opt_base):
-            for key, value in sorted(six.iteritems(parent), key=par_cmp):
+            for key, value in sorted(parent.items(), key=par_cmp):
                 opt_base_copy = opt_base[:]
                 if opt_base != PAR_PREFIX:
                     opt_base_copy += "."
@@ -579,7 +575,7 @@ class ParameterDict(dict):
             opt_base_copy = opt_base[:]
             if opt_base != PAR_PREFIX:
                 opt_base_copy += "."
-            for key, value in sorted(six.iteritems(parent), key=par_cmp):
+            for key, value in sorted(parent.items(), key=par_cmp):
                 # If the value is a ParameterDict
                 if isinstance(value, ParameterDict):
                     # Call the function recursively
@@ -597,10 +593,10 @@ class ParameterDict(dict):
                 ret_list.append(f"{opt_base_copy}{key}")
                 if type(value) in [list, tuple]:
                     for item in value:
-                        ret_list.append(six.text_type(item))
+                        ret_list.append(str(item))
                 else:
                     value = int(value) if isinstance(value, bool) else value
-                    ret_list.append(six.text_type(value))
+                    ret_list.append(str(value))
 
             return ret_list
 

--- a/modelparameters/parameters.py
+++ b/modelparameters/parameters.py
@@ -44,7 +44,6 @@ except ImportError:
     dummy_sym = None
 
 import copy
-import six
 
 # local imports
 from .logger import value_error, error, type_error, info, warning, debug
@@ -766,7 +765,7 @@ class ScalarParam(Param):
         self._range = Range(ge, le, gt, lt)
         self._in_range = self._range._in_range
 
-        check_kwarg(unit, "unit", six.string_types)
+        check_kwarg(unit, "unit", str)
         self._unit = unit
 
         # Define some string used for pretty print

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ install_requires =
     mpmath
     numpy
     pint
-    six
 python_requires = >=3.6
 include_package_data = True
 zip_safe = False

--- a/tests/test_parameterdict.py
+++ b/tests/test_parameterdict.py
@@ -1,8 +1,6 @@
 """test for parameters module"""
 import unittest
 
-import six
-
 from modelparameters.logger import suppress_logging
 from modelparameters.parameterdict import ParameterDict
 from modelparameters.parameters import ConstParam
@@ -76,15 +74,15 @@ something_very_long =    '3'""".decode(
         if sp:
             cmp_str += "\nzlave           =    2.5 - SlaveParam(base0*base1)"
 
-        self.assertEqual(six.text_type(p), cmp_str)
+        self.assertEqual(str(p), cmp_str)
 
         p.b.bblal = 98
         p.b.bling = "jada"
         cmp_str = cmp_str.replace("987", " 98").replace(" 'akjh' ", " 'jada' ")
-        self.assertEqual(six.text_type(p), cmp_str)
+        self.assertEqual(str(p), cmp_str)
 
         # Test copy
-        self.assertEqual(six.text_type(p.copy()), cmp_str)
+        self.assertEqual(str(p.copy()), cmp_str)
         self.assertEqual(
             p.copy(True),
             eval(
@@ -98,7 +96,7 @@ something_very_long =    '3'""".decode(
         if sp:
             base1.value = 1.0
             cmp_str = cmp_str.replace("2.5", "5.0")
-            self.assertEqual(six.text_type(p), cmp_str)
+            self.assertEqual(str(p), cmp_str)
 
     def test_assignments(self):
 
@@ -122,7 +120,7 @@ something_very_long =    '3'""".decode(
         with self.assertRaises(ValueError) as cm:
             p.b.bling = "snada"
         self.assertEqual(
-            six.text_type(cm.exception),
+            str(cm.exception),
             "Illegal value 'bling': 'snada' "
             + b"\xe2\x88\x89 ['akjh', 'bla', 'jada', 'smada']".decode("utf-8"),
         )
@@ -193,7 +191,7 @@ something_very_long =    '3'""".decode(
         with self.assertRaises(ValueError) as cm:
             p.parse_args(["--other", "-1"])
         self.assertEqual(
-            six.text_type(cm.exception),
+            str(cm.exception),
             (
                 "Trying to set 'other' while parsing "
                 + "command line, but Illegal value 'other': -1.0 "

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,8 +1,6 @@
 """test for parameters module"""
 import unittest
 
-import six
-
 from modelparameters.logger import suppress_logging
 from modelparameters.parameters import ArrayParam
 from modelparameters.parameters import ConstParam
@@ -150,7 +148,7 @@ class TestOptionParam(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             OptionParam(46, [45, 56])
         self.assertEqual(
-            six.text_type(cm.exception),
+            str(cm.exception),
             "Illegal value: 46 " + b"\xe2\x88\x89 [45, 56]".decode("utf-8"),
         )
 
@@ -167,7 +165,7 @@ class TestOptionParam(unittest.TestCase):
             "OptionParam(45, [45, 56], name='bada')",
         )
         self.assertEqual(
-            six.text_type(OptionParam(45, [45, 56], "bada")),
+            str(OptionParam(45, [45, 56], "bada")),
             b"45 \xe2\x88\x88 [45, 56]".decode("utf-8"),
         )
 
@@ -206,7 +204,7 @@ class TestOptionParam(unittest.TestCase):
             p = OptionParam(45, [45, 56], "jada")
             p.value = 57
         self.assertEqual(
-            six.text_type(cm.exception),
+            str(cm.exception),
             "Illegal value 'jada': 57 " + b"\xe2\x88\x89 [45, 56]".decode("utf-8"),
         )
 
@@ -324,7 +322,7 @@ class TestScalarParam(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             ScalarParam(45, 50)
         self.assertEqual(
-            six.text_type(cm.exception),
+            str(cm.exception),
             b"Illegal value: 45 \xe2\x88\x89 ".decode("utf-8")
             + b"[50, \xe2\x88\x9e]".decode("utf-8"),
         )
@@ -332,7 +330,7 @@ class TestScalarParam(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             ScalarParam(45, 0, lt=10)
         self.assertEqual(
-            six.text_type(cm.exception),
+            str(cm.exception),
             b"Illegal value: 45 \xe2\x88\x89 ".decode("utf-8") + "[0, 10)",
         )
 
@@ -367,7 +365,7 @@ class TestScalarParam(unittest.TestCase):
             p = ScalarParam(5, 0, lt=10)
             p.value = 56
         self.assertEqual(
-            six.text_type(cm.exception),
+            str(cm.exception),
             "Illegal value: 56 " + b"\xe2\x88\x89 [0, 10)".decode("utf-8"),
         )
 
@@ -518,7 +516,7 @@ if np is not None:
             with self.assertRaises(ValueError) as cm:
                 ArrayParam(45, 0)
             self.assertEqual(
-                six.text_type(cm.exception),
+                str(cm.exception),
                 b"0 \xe2\x88\x89 [1, ".decode("utf-8")
                 + b"\xe2\x88\x9e] as the 'size' argument while ".decode("utf-8")
                 + "instantiating 'ArrayParam'",
@@ -534,7 +532,7 @@ if np is not None:
             with self.assertRaises(ValueError) as cm:
                 ArrayParam(np.array([40, 60, 45]), ge=50)
             self.assertEqual(
-                six.text_type(cm.exception),
+                str(cm.exception),
                 "Illegal value: [40, 60, 45] "
                 + b"\xe2\x88\x89 [50, \xe2\x88\x9e]".decode("utf-8"),
             )
@@ -542,7 +540,7 @@ if np is not None:
             with self.assertRaises(ValueError) as cm:
                 ArrayParam(45, 4, ge=0, lt=10)
             self.assertEqual(
-                six.text_type(cm.exception),
+                str(cm.exception),
                 "Illegal value: [45, 45, 45, 45]"
                 + b" \xe2\x88\x89 [0, 10)".decode("utf-8"),
             )
@@ -580,7 +578,7 @@ if np is not None:
                 p = ArrayParam(5, 4, ge=0, lt=10)
                 p.value = 56
             self.assertEqual(
-                six.text_type(cm.exception),
+                str(cm.exception),
                 "Illegal value: 56 " + b"\xe2\x88\x89 [0, 10)".decode("utf-8"),
             )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,6 @@ except ImportError:
     np = None
 
 import unittest
-import six
 
 from modelparameters.logger import suppress_logging
 from modelparameters.utils import (
@@ -62,7 +61,7 @@ class RangeTests(unittest.TestCase):
         self.assertEqual(Range(gt=0), Range(gt=0))
         self.assertEqual(repr(Range(gt=0)), "Range(gt=0)")
         self.assertEqual(
-            six.text_type(Range(gt=0)),
+            str(Range(gt=0)),
             b"(0, \xe2\x88\x9e]".decode("utf-8"),
         )
 
@@ -144,7 +143,7 @@ class CheckArgs(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             check_arg(1, int, context=dummy, gt=2)
         self.assertEqual(
-            six.text_type(cm.exception),
+            str(cm.exception),
             b"1 \xe2\x88\x89 (2, \xe2\x88\x9e] ".decode("utf-8")
             + "while calling 'dummy'",
         )
@@ -152,14 +151,14 @@ class CheckArgs(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             check_arg(1, int, gt=2, le=3)
         self.assertEqual(
-            six.text_type(cm.exception),
+            str(cm.exception),
             b"1 \xe2\x88\x89 (2, 3]".decode("utf-8"),
         )
 
         with self.assertRaises(ValueError) as cm:
             check_arg(5, int, ge=2, lt=3)
         self.assertEqual(
-            six.text_type(cm.exception),
+            str(cm.exception),
             b"5 \xe2\x88\x89 [2, 3)".decode("utf-8"),
         )
 
@@ -213,7 +212,7 @@ class CheckArgs(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             check_kwarg(1, "bada", int, context=dummy, gt=2)
         self.assertEqual(
-            six.text_type(cm.exception),
+            str(cm.exception),
             b"1 \xe2\x88\x89 (2, \xe2\x88\x9e] ".decode("utf-8")
             + "as the 'bada' argument while calling 'dummy'",
         )
@@ -221,14 +220,14 @@ class CheckArgs(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             check_kwarg(1, "bada", int, gt=2, le=3)
         self.assertEqual(
-            six.text_type(cm.exception),
+            str(cm.exception),
             b"1 \xe2\x88\x89 (2, 3] ".decode("utf-8") + "as the 'bada' argument",
         )
 
         with self.assertRaises(ValueError) as cm:
             check_kwarg(5, "bada", int, ge=2, lt=3)
         self.assertEqual(
-            six.text_type(cm.exception),
+            str(cm.exception),
             b"5 \xe2\x88\x89 [2, 3) ".decode("utf-8") + "as the 'bada' argument",
         )
 


### PR DESCRIPTION
We do not support python2 anymore, so no need to use `six`